### PR TITLE
Separate all the classes used by Interpreter into their own TypeScript files

### DIFF
--- a/src/js/salliedforth.ts
+++ b/src/js/salliedforth.ts
@@ -1,3 +1,5 @@
+import { Interpreter } from "../ts/Interpreter";
+
 "use strict";
 
 /**

--- a/src/ts/ArrayCommand.ts
+++ b/src/ts/ArrayCommand.ts
@@ -1,4 +1,3 @@
-
 export class ArrayCommand {
   _data: any[];
   fn: () => void;

--- a/src/ts/CommandStack.ts
+++ b/src/ts/CommandStack.ts
@@ -1,6 +1,5 @@
 import { Stack } from "./Stack";
 
-
 export class CommandStack extends Stack {
   constructor() {
     super("Command Stack");

--- a/src/ts/ObjectCommand.ts
+++ b/src/ts/ObjectCommand.ts
@@ -1,4 +1,3 @@
-
 export class ObjectCommand {
   _data: { [key: string]: any; };
   fn: () => void;

--- a/src/ts/ResponseData.ts
+++ b/src/ts/ResponseData.ts
@@ -1,4 +1,3 @@
-
 export class ResponseData {
   data: any[];
   status: string;

--- a/src/ts/Stack.ts
+++ b/src/ts/Stack.ts
@@ -1,4 +1,3 @@
-
 export class Stack {
   name: string;
   _stack: any[];

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -1,4 +1,3 @@
-
 export function mergeIn(obj1: any, obj2: any) {
     for (const attrname in obj2) {
         if (obj2.hasOwnProperty(attrname)) {
@@ -8,7 +7,9 @@ export function mergeIn(obj1: any, obj2: any) {
         }
     }
     return obj1;
-}export function pathRecur(pth: string[], str: any) {
+}
+
+export function pathRecur(pth: string[], str: any) {
   if (pth.length > 0) {
     const nxt = pth.shift();
     const data = nxt !== undefined ? str[nxt] : undefined;
@@ -19,15 +20,18 @@ export function mergeIn(obj1: any, obj2: any) {
   }
   return str;
 }
+
 export function isObject(obj: any) {
   return obj === Object(obj);
 }
+
 export function addMetaData(inst: any, meta: any) {
   inst.getMetaData = function () {
     return meta;
   };
   return inst;
 }
+
 export function construct(constructor: any, args: any[]) {
   function F() {
     return constructor.apply(this, args);
@@ -44,4 +48,3 @@ export function construct(constructor: any, args: any[]) {
   }
   return new F();
 }
-

--- a/tests/index.html
+++ b/tests/index.html
@@ -57,7 +57,7 @@
         }
       }
     </script>
-    <script src="js/salliedforth-interpreter-test.ts"></script>
+    <script src="js/salliedforth-interpreter-test.js"></script>
     <script src="spec/stack-manipulation.spec.ts"></script>
     <script src="spec/maths.spec.ts"></script>
     <script src="spec/flow-control.spec.ts"></script>

--- a/tests/js/salliedforth-interpreter-test.ts
+++ b/tests/js/salliedforth-interpreter-test.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("The Interpreter", function() {
 

--- a/tests/spec/browser.spec.ts
+++ b/tests/spec/browser.spec.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("Browser interop", function() {
 

--- a/tests/spec/defining-words.spec.ts
+++ b/tests/spec/defining-words.spec.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("Browser interop", function() {
 

--- a/tests/spec/flow-control.spec.ts
+++ b/tests/spec/flow-control.spec.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("Flow Control", function() {
 

--- a/tests/spec/javascript-interop.spec.ts
+++ b/tests/spec/javascript-interop.spec.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("JavaScript interoperability", function() {
 

--- a/tests/spec/maths.spec.ts
+++ b/tests/spec/maths.spec.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("Maths functions", function() {
 

--- a/tests/spec/return-stack.spec.ts
+++ b/tests/spec/return-stack.spec.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("Return Stack functions", function() {
 

--- a/tests/spec/stack-manipulation.spec.ts
+++ b/tests/spec/stack-manipulation.spec.ts
@@ -1,4 +1,4 @@
-import { Interpreter } from '../../src/js/salliedforth';
+import { Interpreter } from '../../src/ts/Interpreter';
 
 describe("Stack Manipulation", function() {
 


### PR DESCRIPTION
Separate classes used by Interpreter into their own TypeScript files.

* Add `ArrayCommand` class implementation in `src/ts/ArrayCommand.ts`.
* Add `CommandStack` class implementation in `src/ts/CommandStack.ts`.
* Add `ObjectCommand` class implementation in `src/ts/ObjectCommand.ts`.
* Add `ResponseData` class implementation in `src/ts/ResponseData.ts`.
* Add `Stack` class implementation in `src/ts/Stack.ts`.
* Add utility functions `mergeIn`, `pathRecur`, `isObject`, `addMetaData`, and `construct` in `src/ts/util.ts`.
* Import `Interpreter` class from `src/ts/Interpreter.ts` in `src/js/salliedforth.ts`.
* Update script tag to include the new `salliedforth-interpreter-test.js` file in `tests/index.html`.
* Update import statements to import the `Interpreter` class from `src/ts/Interpreter.ts` in the following test files:
  - `tests/js/salliedforth-interpreter-test.ts`
  - `tests/spec/browser.spec.ts`
  - `tests/spec/defining-words.spec.ts`
  - `tests/spec/flow-control.spec.ts`
  - `tests/spec/javascript-interop.spec.ts`
  - `tests/spec/maths.spec.ts`
  - `tests/spec/return-stack.spec.ts`
  - `tests/spec/stack-manipulation.spec.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jococo/sallied-forth?shareId=49531215-3413-4e2b-947c-b2ca0e3cb693).